### PR TITLE
Use recent setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ USER root
 # Volume for sharing wrapper script
 VOLUME /utils
 RUN apt-get update
-RUN apt-get -y install apt-utils python wget build-essential python-dev swig libevent-dev python-protobuf libprotobuf-dev libcurl4-gnutls-dev python-setuptools libxml2-dev libxslt-dev libblas-dev liblapack-dev gfortran libfreetype6-dev libpng-dev
-
-RUN wget http://arshaw.com/scrapemark/downloads/scrapemark-0.9-py2.7.egg; easy_install scrapemark-0.9-py2.7.egg
+RUN apt-get -y install apt-utils python wget build-essential python-dev swig libevent-dev python-protobuf libprotobuf-dev libcurl4-gnutls-dev libxml2-dev libxslt-dev libblas-dev liblapack-dev gfortran libfreetype6-dev libpng-dev
 
 # Install pip
 RUN wget https://bootstrap.pypa.io/get-pip.py; python get-pip.py
+
+RUN wget http://arshaw.com/scrapemark/downloads/scrapemark-0.9-py2.7.egg; easy_install scrapemark-0.9-py2.7.egg
 
 # This needs to be installed first
 RUN pip install numpy==1.6.1

--- a/requirements.in
+++ b/requirements.in
@@ -10,7 +10,7 @@ python-Levenshtein==0.10.2
 python-dateutil==1.5
 python-gflags==2.0
 python-modargs==1.2
-python-stdnum==0.7
+python-stdnum==1.0
 requests==2.4.3
 simplejson==2.2.1
 turbotlib==0.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ python-editor==1.0.3      # via alembic
 python-gflags==2.0
 python-Levenshtein==0.10.2
 python-modargs==1.2
-python-stdnum==0.7
+python-stdnum==1.0
 PyYAML==3.11
 queuelib==1.4.2           # via scrapy
 requests==2.4.3
@@ -55,5 +55,4 @@ xlrd==0.9.3
 zope.interface==4.3.3     # via twisted
 
 # The following packages are considered to be unsafe in a requirements file:
-# distribute                # via python-stdnum
-# setuptools                # via cryptography, distribute, python-levenshtein, zope.interface
+# setuptools                # via cryptography, python-levenshtein, zope.interface


### PR DESCRIPTION
The `python-setuptools` package installed a very old version of `setuptools`. Instead we can use the version that gets installed with `pip`. This requires re-ordering some of the Dockerfile steps and installing `distribute` explicitly.